### PR TITLE
fix: frontend routing

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    location / {
+        # First attempt to serve request as file, then as directory, then fall back to redirecting to index.html
+        # This is needed for history mode in React Router.
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN npm install -g nodemon --unsafe-perm && npm ci --no-audit && npm run build
 
 FROM nginx:stable-alpine-slim
 
+COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
 RUN rm -rf /usr/share/nginx/html/*
-
 COPY --from=build /status-frontend/build/ /usr/share/nginx/html/
 
 EXPOSE 80


### PR DESCRIPTION
Right now it's impossible to access the frontend directly at whatever subpage is requested (for instance, it's impossible to access ``/login`` by setting the address manually, it's only possible through the frontend itself, so loading the index first is required).